### PR TITLE
RSDK-10712 Enrich STUN logs

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -1000,7 +1000,7 @@ func (a *Agent) findRemoteCandidate(networkType NetworkType, addr net.Addr) Cand
 }
 
 func (a *Agent) sendBindingRequest(m *stun.Message, local, remote Candidate) {
-	a.log.Tracef("Ping STUN from %s to %s", local, remote)
+	a.log.Tracef("Ping STUN from %s to %s (Transaction ID: %v)", local, remote, m.TransactionID)
 
 	a.invalidatePendingBindingRequests(time.Now())
 	a.pendingBindingRequests = append(a.pendingBindingRequests, bindingRequest{
@@ -1088,15 +1088,21 @@ func (a *Agent) handleInbound(m *stun.Message, local Candidate, remote net.Addr)
 
 	if a.isControlling {
 		if m.Contains(stun.AttrICEControlling) {
-			a.log.Debug("Inbound STUN message: isControlling && a.isControlling == true")
+			a.log.Debugf(
+				"Inbound STUN message: isControlling && a.isControlling == true (Transaction ID: %v)",
+				m.TransactionID,
+			)
 			return
 		} else if m.Contains(stun.AttrUseCandidate) {
-			a.log.Debug("Inbound STUN message: useCandidate && a.isControlling == true")
+			a.log.Debugf(
+				"Inbound STUN message: useCandidate && a.isControlling == true (Transaction ID: %v)",
+				m.TransactionID,
+			)
 			return
 		}
 	} else {
 		if m.Contains(stun.AttrICEControlled) {
-			a.log.Debug("Inbound STUN message: isControlled && a.isControlling == false")
+			a.log.Debugf("Inbound STUN message: isControlled && a.isControlling == false (Transaction ID: %v)", m.TransactionID)
 			return
 		}
 	}
@@ -1115,7 +1121,8 @@ func (a *Agent) handleInbound(m *stun.Message, local Candidate, remote net.Addr)
 
 		a.selector.HandleSuccessResponse(m, local, remoteCandidate, remote)
 	} else if m.Type.Class == stun.ClassRequest {
-		a.log.Tracef("Inbound STUN (Request) from %s to %s, useCandidate: %v", remote, local, m.Contains(stun.AttrUseCandidate))
+		a.log.Tracef("Inbound STUN (Request) from %s to %s, useCandidate: %v (Transaction ID: %v)",
+			remote, local, m.Contains(stun.AttrUseCandidate), m.TransactionID)
 
 		if err = stunx.AssertUsername(m, a.localUfrag+":"+a.remoteUfrag); err != nil {
 			a.log.Warnf("Discard message from (%s), %v", remote, err)

--- a/agent.go
+++ b/agent.go
@@ -7,6 +7,7 @@ package ice
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"math"
@@ -1000,7 +1001,8 @@ func (a *Agent) findRemoteCandidate(networkType NetworkType, addr net.Addr) Cand
 }
 
 func (a *Agent) sendBindingRequest(m *stun.Message, local, remote Candidate) {
-	a.log.Tracef("Ping STUN from %s to %s (Transaction ID: %v)", local, remote, m.TransactionID)
+	encodedTransactionID := base64.StdEncoding.EncodeToString(m.TransactionID[:])
+	a.log.Tracef("Ping STUN from %s to %s (Transaction ID: %s)", local, remote, encodedTransactionID)
 
 	a.invalidatePendingBindingRequests(time.Now())
 	a.pendingBindingRequests = append(a.pendingBindingRequests, bindingRequest{
@@ -1086,26 +1088,32 @@ func (a *Agent) handleInbound(m *stun.Message, local Candidate, remote net.Addr)
 		return
 	}
 
+	var isICEControlling, isUseCandidate, isICEControlled bool
 	if a.isControlling {
 		if m.Contains(stun.AttrICEControlling) {
-			a.log.Debugf(
-				"Inbound STUN message: isControlling && a.isControlling == true (Transaction ID: %v)",
-				m.TransactionID,
-			)
-			return
+			isICEControlling = true
 		} else if m.Contains(stun.AttrUseCandidate) {
-			a.log.Debugf(
-				"Inbound STUN message: useCandidate && a.isControlling == true (Transaction ID: %v)",
-				m.TransactionID,
-			)
-			return
+			isUseCandidate = true
 		}
 	} else {
 		if m.Contains(stun.AttrICEControlled) {
-			a.log.Debugf("Inbound STUN message: isControlled && a.isControlling == false (Transaction ID: %v)", m.TransactionID)
-			return
+			isICEControlled = true
 		}
 	}
+
+	encodedTransactionID := base64.StdEncoding.EncodeToString(m.TransactionID[:])
+	a.log.Debugf(
+		"Inbound STUN message. From: (%s) To: (%s) Method: (%s) Class: (%s) ICEControlling: (%v) UseCandidate: (%v) ICEControlled: (%v) a.isControlling: (%v) TransactionID: (%s)",
+		remote,
+		local,
+		m.Type.Method,
+		m.Type.Class,
+		isICEControlling,
+		isUseCandidate,
+		isICEControlled,
+		a.isControlling,
+		encodedTransactionID,
+	)
 
 	remoteCandidate := a.findRemoteCandidate(local.NetworkType(), remote)
 	if m.Type.Class == stun.ClassSuccessResponse {
@@ -1121,9 +1129,6 @@ func (a *Agent) handleInbound(m *stun.Message, local Candidate, remote net.Addr)
 
 		a.selector.HandleSuccessResponse(m, local, remoteCandidate, remote)
 	} else if m.Type.Class == stun.ClassRequest {
-		a.log.Tracef("Inbound STUN (Request) from %s to %s, useCandidate: %v (Transaction ID: %v)",
-			remote, local, m.Contains(stun.AttrUseCandidate), m.TransactionID)
-
 		if err = stunx.AssertUsername(m, a.localUfrag+":"+a.remoteUfrag); err != nil {
 			a.log.Warnf("Discard message from (%s), %v", remote, err)
 			return

--- a/selection.go
+++ b/selection.go
@@ -4,6 +4,7 @@
 package ice
 
 import (
+	"encoding/base64"
 	"net"
 	"time"
 
@@ -87,8 +88,9 @@ func (s *controllingSelector) nominatePair(pair *CandidatePair) {
 		return
 	}
 
-	s.log.Tracef("Ping STUN (nominate candidate pair) from %s to %s (Transaction ID: %v)",
-		pair.Local, pair.Remote, msg.TransactionID)
+	encodedTransactionID := base64.StdEncoding.EncodeToString(msg.TransactionID[:])
+	s.log.Tracef("Ping STUN (nominate candidate pair) from %s to %s (Transaction ID: %s)",
+		pair.Local, pair.Remote, encodedTransactionID)
 	s.agent.sendBindingRequest(msg, pair.Local, pair.Remote)
 }
 
@@ -136,7 +138,9 @@ func (s *controllingSelector) HandleSuccessResponse(m *stun.Message, local, remo
 		return
 	}
 
-	s.log.Tracef("Inbound STUN (SuccessResponse) from %s to %s (Transaction ID: %v)", remote, local, m.TransactionID)
+	encodedTransactionID := base64.StdEncoding.EncodeToString(m.TransactionID[:])
+	s.log.Tracef("Inbound STUN (SuccessResponse) from %s to %s (Transaction ID: %s)", remote, local,
+		encodedTransactionID)
 	p := s.agent.findPair(local, remote)
 
 	if p == nil {
@@ -229,7 +233,9 @@ func (s *controlledSelector) HandleSuccessResponse(m *stun.Message, local, remot
 		return
 	}
 
-	s.log.Tracef("Inbound STUN (SuccessResponse) from %s to %s (Transaction ID: %v)", remote, local, m.TransactionID)
+	encodedTransactionID := base64.StdEncoding.EncodeToString(m.TransactionID[:])
+	s.log.Tracef("Inbound STUN (SuccessResponse) from %s to %s (Transaction ID: %s)", remote, local,
+		encodedTransactionID)
 
 	p := s.agent.findPair(local, remote)
 	if p == nil {

--- a/selection.go
+++ b/selection.go
@@ -87,7 +87,8 @@ func (s *controllingSelector) nominatePair(pair *CandidatePair) {
 		return
 	}
 
-	s.log.Tracef("Ping STUN (nominate candidate pair) from %s to %s", pair.Local, pair.Remote)
+	s.log.Tracef("Ping STUN (nominate candidate pair) from %s to %s (Transaction ID: %v)",
+		pair.Local, pair.Remote, msg.TransactionID)
 	s.agent.sendBindingRequest(msg, pair.Local, pair.Remote)
 }
 
@@ -135,7 +136,7 @@ func (s *controllingSelector) HandleSuccessResponse(m *stun.Message, local, remo
 		return
 	}
 
-	s.log.Tracef("Inbound STUN (SuccessResponse) from %s to %s", remote, local)
+	s.log.Tracef("Inbound STUN (SuccessResponse) from %s to %s (Transaction ID: %v)", remote, local, m.TransactionID)
 	p := s.agent.findPair(local, remote)
 
 	if p == nil {
@@ -228,7 +229,7 @@ func (s *controlledSelector) HandleSuccessResponse(m *stun.Message, local, remot
 		return
 	}
 
-	s.log.Tracef("Inbound STUN (SuccessResponse) from %s to %s", remote, local)
+	s.log.Tracef("Inbound STUN (SuccessResponse) from %s to %s (Transaction ID: %v)", remote, local, m.TransactionID)
 
 	p := s.agent.findPair(local, remote)
 	if p == nil {


### PR DESCRIPTION
[RSDK-10712](https://viam.atlassian.net/browse/RSDK-10712)

Enriches ICE STUN logs now that we have our own branch. I have attached files representing what `PION_LOG_TRACE=ice` output looks like for successful connection establishment (and will keep them updated as the PR progresses).

[with_transaction_id.txt](https://github.com/user-attachments/files/20416297/with_transaction_id.txt)
[without_transaction_id.txt](https://github.com/user-attachments/files/20416298/without_transaction_id.txt)

[RSDK-10712]: https://viam.atlassian.net/browse/RSDK-10712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

cc @viamrobotics/netcode 